### PR TITLE
use `go.version` for version check

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, buildGoPackage, go, makeWrapper, nix-prefetch-git }:
 
-assert lib.versionAtLeast go "1.11";
+assert lib.versionAtLeast go.version "1.11";
 buildGoPackage rec {
   name = "vgo2nix-${version}";
   version = "0.0.1";


### PR DESCRIPTION
`versionAtLeast` should take two strings instead of a set and string

Without this change I get `error: value is a set while a string was expected` when `nix-build`ing.