### PR TITLE
Fix hash mismatch when the repo of a dependency has submodules

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,9 +133,15 @@ func getPackages(keepGoing bool, numJobs int, prevDeps map[string]*Package) ([]*
 		}
 
 		fmt.Println(fmt.Sprintf("Fetching %s", goPackagePath))
+		// The options for nix-prefetch-git need to match how buildGoPackage
+		// calls fetchgit:
+		// https://github.com/NixOS/nixpkgs/blob/8d8e56824de52a0c7a64d2ad2c4ed75ed85f446a/pkgs/development/go-modules/generic/default.nix#L54-L56
+		// and fetchgit's defaults:
+		// https://github.com/NixOS/nixpkgs/blob/8d8e56824de52a0c7a64d2ad2c4ed75ed85f446a/pkgs/build-support/fetchgit/default.nix#L15-L23
 		jsonOut, err := exec.Command(
 			"nix-prefetch-git",
 			"--quiet",
+			"--fetch-submodules",
 			"--url", repoRoot.Repo,
 			"--rev", entry.rev).Output()
 		fmt.Println(fmt.Sprintf("Finished fetching %s", goPackagePath))


### PR DESCRIPTION
The mismatch happened when I tried to build [segmentio/chamber](https://github.com/segmentio/chamber), which depends on [segmentio/backo-go](https://github.com/segmentio/backo-go).

The error looks like:

> fixed-output derivation produced path '/nix/store/...' with sha256
> hash '<actual hash>' instead of the expected hash '<hash produced by vgo2nix>'

How this happened, to my understanding:

- buildGoPackage calls fetchgit with only url, rev, and sha256 specified:
https://github.com/NixOS/nixpkgs/blob/8d8e56824de52a0c7a64d2ad2c4ed75ed85f446a/pkgs/development/go-modules/generic/default.nix#L54-L56
- fetchgit's default for fetchSubmodules is true:
https://github.com/NixOS/nixpkgs/blob/8d8e56824de52a0c7a64d2ad2c4ed75ed85f446a/pkgs/build-support/fetchgit/default.nix#L16
- while nix-prefetch-git script's default is false:
https://github.com/NixOS/nixpkgs/blob/8d8e56824de52a0c7a64d2ad2c4ed75ed85f446a/pkgs/build-support/fetchgit/nix-prefetch-git#L11

Until the mismatch in defaults is fixed upstream, which is tracked [here](NixOS/nixpkgs#27033), the easiest fix is to match how we call nix-prefetch-git with how fetchgit is called.

