### PR TITLE
default.nix: allow to pass pkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,5 @@
-with import <nixpkgs> {};
+{ pkgs ? import <nixpkgs> {} }:
+with pkgs;
 
 assert lib.versionAtLeast go.version "1.11";
 buildGoPackage rec {

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -1,7 +1,7 @@
 with import <nixpkgs> {};
 
 let
-  vgo2nix = import ../default.nix;
+  vgo2nix = import ../default.nix {};
 
 in mkShell {
   buildInputs = [


### PR DESCRIPTION
allow the user to compose the repository into an existing nixpkgs
overlay.